### PR TITLE
Update | Adding the redeploy script to Git

### DIFF
--- a/REDEPLOY.sh
+++ b/REDEPLOY.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source .env
+
+docker pull jlai241/stacc-api:$API_VERSION
+docker compose down
+docker compose --env-file .env --env-file .compose-env up -d api


### PR DESCRIPTION
# Description

This PR just adds the `REDEPLOY.sh` script to Git for tracking purposes. For context, here is how this script is used:

After a new version of the API is published to Docker, I `ssh` into my DigitalOcean Droplet, run `git pull` in this repo (which I have cloned in my Droplet), and then I run the redeploy script to pull the latest Docker image from Docker Hub and restart the `api` service.

# Type of Change

> **TIP:** You can mark a box by replacing the space with an `x`.

- [x] Adding file to Git tracking
- [ ] Bug Fix (non-breaking change which fixes an issue)
- [ ] Bug Fix - Breaking Change (breaking change causes existing functionality to not work as expected)
- [ ] Code Refactor
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] New Feature - Breaking Change (breaking change causes existing functionality to not work as expected)
- [ ] This change requires a documentation update
