### PR TITLE
Hotfix/Update | Rendering `victim ages` table, background refresh fix, and adding source code link

### DIFF
--- a/frontend/src/pages/about.rs
+++ b/frontend/src/pages/about.rs
@@ -41,7 +41,9 @@ and a place to blog about all things computer science."#;
               <a href="https://yew.rs"><code>{ "Yew" }</code></a>
               { " to implement the frontend and " }
               <a href="https://actix.rs"><code>{ "Actix Web" }</code></a>
-              { " to implement the API." }
+              { " to implement the API. The " }
+              <a href="https://github.com/JosephLai241/stacc">{ "source code" }</a>
+              { " is available on my GitHub." }
             </p>
             <div class="image-container">
               <a class="social-icon" href="https://github.com/JosephLai241">

--- a/frontend/src/pages/blog.rs
+++ b/frontend/src/pages/blog.rs
@@ -18,7 +18,6 @@ use crate::FAVICON_GIF;
 /// The blog page.
 #[function_component(Blog)]
 pub fn blog() -> Html {
-    background::set_background(true);
     gloo_utils::document().set_title("jl | blog");
 
     let is_loading = use_state(|| true);
@@ -29,6 +28,8 @@ pub fn blog() -> Html {
 
         use_effect_with_deps(
             move |_| {
+                background::set_background(true);
+
                 wasm_bindgen_futures::spawn_local(async move {
                     open_graph::set_open_graph_tag(OpenGraphTag::Description(
                         "my blog".to_string(),

--- a/frontend/src/pages/not_found.rs
+++ b/frontend/src/pages/not_found.rs
@@ -17,7 +17,6 @@ use crate::{
 /// The 404 Not Found page.
 #[function_component(NotFound)]
 pub fn not_found() -> Html {
-    background::set_background(true);
     gloo_utils::document().set_title("jl | 404");
 
     let is_loading = use_state(|| true);
@@ -28,6 +27,8 @@ pub fn not_found() -> Html {
 
         use_effect_with_deps(
             move |_| {
+                background::set_background(true);
+
                 wasm_bindgen_futures::spawn_local(async move {
                     open_graph::set_open_graph_tag(OpenGraphTag::Description(
                         "go the fuck home".to_string(),

--- a/frontend/src/pages/post_view.rs
+++ b/frontend/src/pages/post_view.rs
@@ -24,8 +24,6 @@ pub struct PostViewProps {
 /// The post view page.
 #[function_component(PostView)]
 pub fn post_view(props: &PostViewProps) -> Html {
-    background::set_background(true);
-
     let post_id = props.post_id.clone();
 
     let is_loading = use_state(|| true);
@@ -36,6 +34,8 @@ pub fn post_view(props: &PostViewProps) -> Html {
 
         use_effect_with_deps(
             move |_| {
+                background::set_background(true);
+
                 open_graph::set_open_graph_tag(OpenGraphTag::PageType(PageType::Article))
                     .unwrap_or_else(|error| error!(error.to_string()));
                 open_graph::set_open_graph_tag(OpenGraphTag::Url(format!(

--- a/frontend/src/pages/violence.rs
+++ b/frontend/src/pages/violence.rs
@@ -74,7 +74,6 @@ lazy_static! {
 /// The Chicago ShotSpotter map page.
 #[function_component(Violence)]
 pub fn violence() -> Html {
-    background::set_background(true);
     gloo_utils::document().set_title("jl | violence");
 
     let is_loading = use_state(|| true);
@@ -85,6 +84,8 @@ pub fn violence() -> Html {
 
         use_effect_with_deps(
             move |_| {
+                background::set_background(true);
+
                 wasm_bindgen_futures::spawn_local(async move {
                     open_graph::set_open_graph_tag(OpenGraphTag::Description(
                         "Visualizing violence in Chicago".to_string(),

--- a/frontend/src/pages/violence.rs
+++ b/frontend/src/pages/violence.rs
@@ -440,6 +440,10 @@ fn render_map(chicago_map_data: ChicagoMapData) -> Result<(VNode, VNode, VNode),
                 ("victim race", "occurrences"),
                 &cleaned_violence_data.to_vec("sorted_victim_races")?,
             )?;
+            let victim_ages_table = create_table_from_data(
+                ("victim age range", "occurrences"),
+                &cleaned_violence_data.to_vec("sorted_ages")?,
+            )?;
             let victim_sexes_table = create_table_from_data(
                 ("victim sex", "occurrences"),
                 &cleaned_violence_data.to_vec("sorted_victim_sexes")?,
@@ -457,6 +461,7 @@ fn render_map(chicago_map_data: ChicagoMapData) -> Result<(VNode, VNode, VNode),
             let _ = tables.append_child(&incident_types_table);
             let _ = tables.append_child(&location_description_table);
             let _ = tables.append_child(&victim_races_table);
+            let _ = tables.append_child(&victim_ages_table);
             let _ = tables.append_child(&victim_sexes_table);
             let _ = tables.append_child(&gun_injury_table);
             let _ = tables.append_child(&community_areas_table);


### PR DESCRIPTION
# Description

This PR introduces the following changes to the frontend:

- The `victim ages` table was previously not rendered on the violence page. It has since been added.
- Added a link to the source code in the about page.
- The background GIF was refreshing twice on pages that contain a `use_effect_with_deps()` hook. The background refresh call has been moved into the hook and only refreshes once as intended.

# Type of Change

> **TIP:** You can mark a box by replacing the space with an `x`.

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Bug Fix - Breaking Change (breaking change causes existing functionality to not work as expected)
- [ ] Code Refactor
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] New Feature - Breaking Change (breaking change causes existing functionality to not work as expected)
- [ ] This change requires a documentation update
