### PR TITLE
Hotfix | Updating the order of rules for Leaflet popup borders

### DIFF
--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -630,14 +630,14 @@ code {
 
 .leaflet-popup-content-wrapper {
   background-color: #0b0d10;
-  border: #7d310a solid 1px;
+  border: 1px solid #7d310a;
   box-shadow: 0 3px 14px rgba(0, 0, 0, 0.4);
   color: #808080;
 }
 
 .leaflet-popup-tip {
   background-color: #0b0d10;
-  border: #7d310a solid 1px;
+  border: 1px solid #7d310a;
 }
 
 /* The style for the top right map control container. */


### PR DESCRIPTION
# Description

This PR updates the order of rules for the `border` property for the Leaflet popup's borders. Hopefully this will allow those borders to properly render.

# Type of Change

> **TIP:** You can mark a box by replacing the space with an `x`.

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] Bug Fix - Breaking Change (breaking change causes existing functionality to not work as expected)
- [ ] Code Refactor
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] New Feature - Breaking Change (breaking change causes existing functionality to not work as expected)
- [ ] This change requires a documentation update
